### PR TITLE
Fix lauetools entry-point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if sys.version_info.major == 3:
     import LaueTools
     python3entry_points = {
     'console_scripts': [
-        'lauetools = LaueTools.LaueToolsGUI:start',
+        'lauetools = LaueTools.GUI.mainGUI:start',
 	'peaksearch = LaueTools.FileSeries.Peak_Search:start',
 	'indexrefine = LaueTools.FileSeries.Index_Refine:start',
 	'plotmeshGUI = LaueTools.plotmeshspecGUI:start',


### PR DESCRIPTION
As it is the `lauetools` commands shows this error when closing the GUI:
```
Traceback (most recent call last):
  File "bin/lauetools", line 5, in <module>
    from LaueTools.LaueToolsGUI import start
ImportError: cannot import name 'start' from 'LaueTools.LaueToolsGUI' (lib/python3.12/site-packages/LaueTools/LaueToolsGUI.py)
```

It was working because `LaueTools.LaueToolsGUI` calls `LaueTools.GUI.mainGUI.start()`, but it does not contains `start`.
This PR changes the module to where start is defined.